### PR TITLE
Integrate frontend with backend APIs

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -11,6 +11,9 @@ import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { FcGoogle } from "react-icons/fc"
 
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080/api"
+
 export default function LoginPage() {
   const router = useRouter()
   const [formData, setFormData] = useState({
@@ -23,12 +26,28 @@ export default function LoginPage() {
     setFormData((prev) => ({ ...prev, [name]: value }))
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    console.log("Login submitted:", formData)
-    // In a real app, you would authenticate the user
-    // For now, we'll just redirect to the dashboard
-    router.push("/dashboard")
+    try {
+      const res = await fetch(`${API_BASE_URL}/users/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.message || "Login failed")
+        return
+      }
+      const data = await res.json()
+      if (typeof window !== "undefined") {
+        localStorage.setItem("user", JSON.stringify(data))
+      }
+      router.push("/dashboard")
+    } catch (err) {
+      console.error("Login error", err)
+      alert("Login failed")
+    }
   }
 
   const handleGoogleLogin = () => {

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -12,6 +12,9 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { FcGoogle } from "react-icons/fc"
 
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080/api"
+
 export default function RegisterPage() {
   const router = useRouter()
   const [formData, setFormData] = useState({
@@ -33,12 +36,36 @@ export default function RegisterPage() {
     setFormData((prev) => ({ ...prev, [name]: value }))
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    console.log("Form submitted:", formData)
-    // In a real app, you would send this data to your backend
-    // For now, we'll just redirect to the dashboard
-    router.push("/dashboard")
+    try {
+      const res = await fetch(`${API_BASE_URL}/users/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: formData.fullName,
+          email: formData.email,
+          contact: formData.contact,
+          password: formData.password,
+          country: formData.country,
+          city: formData.city,
+          age: Number.parseInt(formData.age),
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.message || "Registration failed")
+        return
+      }
+      const data = await res.json()
+      if (typeof window !== "undefined") {
+        localStorage.setItem("user", JSON.stringify(data))
+      }
+      router.push("/dashboard")
+    } catch (err) {
+      console.error("Registration error", err)
+      alert("Registration failed")
+    }
   }
 
   const handleGoogleLogin = () => {

--- a/app/dashboard/bus/page.tsx
+++ b/app/dashboard/bus/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
@@ -9,60 +9,28 @@ import { Input } from "@/components/ui/input"
 import { Search, MapPin } from "lucide-react"
 import DashboardLayout from "@/components/dashboard-layout"
 
-// Mock data for agencies
-const agencies = [
-  {
-    id: 1,
-    name: "Vatican Express",
-    location: "Douala",
-    image: "/placeholder.svg?height=200&width=300",
-    rating: 4.5,
-    busCount: 12,
-  },
-  {
-    id: 2,
-    name: "General Express",
-    location: "Yaoundé",
-    image: "/placeholder.svg?height=200&width=300",
-    rating: 4.2,
-    busCount: 8,
-  },
-  {
-    id: 3,
-    name: "Nso Boys",
-    location: "Bamenda",
-    image: "/placeholder.svg?height=200&width=300",
-    rating: 4.0,
-    busCount: 6,
-  },
-  {
-    id: 4,
-    name: "Golden Express",
-    location: "Buea",
-    image: "/placeholder.svg?height=200&width=300",
-    rating: 4.7,
-    busCount: 10,
-  },
-  {
-    id: 5,
-    name: "Musango Express",
-    location: "Limbe",
-    image: "/placeholder.svg?height=200&width=300",
-    rating: 3.9,
-    busCount: 5,
-  },
-  {
-    id: 6,
-    name: "The People Express",
-    location: "Bafoussam",
-    image: "/placeholder.svg?height=200&width=300",
-    rating: 4.3,
-    busCount: 7,
-  },
-]
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080/api"
+
+interface Agency {
+  id: number
+  name: string
+  location: string
+  image?: string
+  rating: number
+  busCount: number
+}
 
 export default function BusAgenciesPage() {
   const [searchTerm, setSearchTerm] = useState("")
+  const [agencies, setAgencies] = useState<Agency[]>([])
+
+  useEffect(() => {
+    fetch(`${API_BASE_URL}/agencies`)
+      .then((res) => res.json())
+      .then((data) => setAgencies(data))
+      .catch((err) => console.error("Failed to load agencies", err))
+  }, [])
 
   const filteredAgencies = agencies.filter(
     (agency) =>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,9 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  env: {
+    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- add API base env to next config
- connect login page to backend register endpoint
- connect registration page to backend login endpoint
- fetch agencies from backend instead of using mock data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d382fe7dc83209479655ba2193bc9